### PR TITLE
Added "View collection in BioFile Finder" link

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -94,6 +94,21 @@ form .filters select {
     padding: 5px;
 }
 
+.collection-header {
+    margin: 0 0 1.2rem;
+    text-align: center;
+}
+
+.collection-header h1 {
+    font-size: 1.3em;
+    margin-bottom: 0em;
+}
+
+.collection-header p {
+    font-size: 1em;
+    margin-bottom: 0em;
+}
+
 .result-details {
     margin: 0 0 1.2rem;
     text-align: center;

--- a/templates/collection.html
+++ b/templates/collection.html
@@ -4,6 +4,14 @@
 <body>
 {% include "topbar.html" %}
 
+<section class="collection-header">   
+    <h1>Searching for images in collection: {{ collection_settings.label }}</h1>
+    <p>
+        <a class="" href="{{ collection_name }}/data.csv">Download metadata</a> as CSV.
+        <a class="" href="{{ get_bff_url(collection_name) }}" target="_blank" rel="noopener noreferrer">View collection in BioFile Finder</a>
+    </p>
+</section>
+
 <section>
 {% include "form.html" %}
 </section>
@@ -14,9 +22,6 @@
 <div class="result-details">
     Showing {{ pagination.start_num }} - {{ pagination.end_num }} 
     of {{ pagination.total_count }} images matching selected criteria.
-
-    <a class="" href="?{{ get_query_string(download='true') }}">Download</a> metadata as CSV.
-
 </div>
 
 {% include "pagination.html" %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -10,7 +10,7 @@
 <ul>
     {% for collection_name in collection_map.keys() %}
     <li>
-        <a href="{{ url_for('collection', collection=collection_name) }}">{{ collections[collection_name].label }}</a>
+        <a href="{{ url_for('collection', collection_name=collection_name) }}">{{ collections[collection_name].label }}</a>
     </li>
     {% endfor %}
 </ul>

--- a/zarrcade/load.py
+++ b/zarrcade/load.py
@@ -164,7 +164,7 @@ def load(settings_path, args):
                 zarr_name, _ = os.path.splitext(image_path)
                 # If we have a discovery URL, use it to find the auxiliary image
                 data_url = str(collection_settings.discovery.data_url)
-                aux_path = os.path.join(data_url, args.aux_path, zarr_name, filename)
+                aux_path = os.path.join(args.aux_path, zarr_name, filename)
                 return aux_path
 
             # If image_path is a URI, extract just the hostname and path components
@@ -176,7 +176,10 @@ def load(settings_path, args):
             aux_path = os.path.join(args.aux_path, zarr_name, filename)
             return aux_path
 
-        thumb_fs = fs if collection_settings.aux_image_mode == 'absolute' else local_fs
+        thumb_fs = local_fs
+        if collection_settings.discovery:
+            data_url = str(collection_settings.discovery.data_url)
+            thumb_fs = get_filestore(data_url)
 
         for dbimage in get_all_images(db, collection_name):
             logger.info(f"Processing {dbimage.path}")


### PR DESCRIPTION
This PR adds a view link that opens the same data in [BioFile Finder](https://github.com/AllenInstitute/biofile-finder), with proxied Neuroglancer links which support multichannel viewing based on the OME-Zarr metadata.

<img width="1385" alt="Screenshot 2025-05-02 at 1 50 17 PM" src="https://github.com/user-attachments/assets/6c74c989-67f5-45ff-aad6-c27bf3733a8e" />

After clicking "View collection in BioFile Finder":

<img width="1512" alt="Screenshot 2025-05-02 at 1 36 12 PM" src="https://github.com/user-attachments/assets/b8d0a08b-b4bb-432b-a314-4d3c864ba71b" />

@StephanPreibisch @SeanLeRoy @joshmoore
