### PR TITLE
Support for Zarr thumbnail convention

### DIFF
--- a/cli/zarrcade_cli/__main__.py
+++ b/cli/zarrcade_cli/__main__.py
@@ -4,6 +4,7 @@ import click
 from loguru import logger
 
 from .commands.discover import discover
+from .commands.embed_thumbnails import embed
 from .commands.generate_mips import mips
 
 
@@ -15,6 +16,7 @@ def cli():
 
 
 cli.add_command(discover)
+cli.add_command(embed)
 cli.add_command(mips)
 
 

--- a/cli/zarrcade_cli/commands/embed_thumbnails.py
+++ b/cli/zarrcade_cli/commands/embed_thumbnails.py
@@ -1,0 +1,195 @@
+"""Embed thumbnails into zarr containers using the thumbnails convention."""
+
+import io
+import os
+import sys
+from typing import Optional
+
+import click
+import fsspec
+import numpy as np
+import pandas as pd
+import skimage as ski
+from loguru import logger
+from PIL import Image
+
+from ..core.filestore import get_filestore
+from ..core.zarr_thumbnails import (
+    SOFTWARE_URL,
+    build_entry,
+    guess_media_type,
+    has_thumbnails,
+    register,
+)
+
+
+def _resolve(path: str, base_url: Optional[str]) -> str:
+    """Resolve a path against an optional base URL."""
+    if base_url and not (path.startswith(("s3://", "http://", "https://", "/"))):
+        return os.path.join(base_url.rstrip("/"), path.lstrip("/"))
+    return path
+
+
+def _read_image_bytes(uri: str) -> bytes:
+    """Read the raw bytes of an image from any fsspec-supported URI."""
+    with fsspec.open(uri, mode="rb") as f:
+        return f.read()
+
+
+def _downsample_with_brightness(
+    src_bytes: bytes,
+    size: int,
+    jpeg_quality: int,
+    p_lower: float,
+    p_upper: float,
+) -> tuple[bytes, int, int]:
+    """Load an image from bytes, adjust brightness via percentile stretch,
+    resize so the longest edge is `size`, and return JPEG bytes plus final
+    (width, height).
+    """
+    with Image.open(io.BytesIO(src_bytes)) as img:
+        img = img.convert("RGB")
+        arr = np.asarray(img)
+
+    lo, hi = np.percentile(arr, (p_lower, p_upper))
+    if hi > lo:
+        arr = ski.exposure.rescale_intensity(arr, in_range=(lo, hi))
+
+    out = Image.fromarray(arr)
+    out.thumbnail((size, size))
+    width, height = out.size
+
+    buf = io.BytesIO()
+    out.save(buf, format="JPEG", quality=jpeg_quality)
+    return buf.getvalue(), width, height
+
+
+def _image_dimensions(src_bytes: bytes) -> tuple[int, int]:
+    with Image.open(io.BytesIO(src_bytes)) as img:
+        return img.size  # (width, height)
+
+
+@click.command()
+@click.option("--input-csv", type=click.Path(exists=True), required=True,
+              help="CSV file with zarr paths in column 1 and thumbnail paths in column 2")
+@click.option("--zarr-base-url", type=str, default=None,
+              help="Base URL to resolve relative zarr paths")
+@click.option("--thumbnail-base-url", type=str, default=None,
+              help="Base URL to resolve relative thumbnail paths")
+@click.option("--size", type=int, default=300, show_default=True,
+              help="Longest edge (pixels) for the downsampled thumbnail")
+@click.option("--jpeg-quality", type=int, default=95, show_default=True,
+              help="JPEG quality for the downsampled thumbnail")
+@click.option("--p-lower", type=float, default=0.0, show_default=True,
+              help="Lower percentile for brightness stretching")
+@click.option("--p-upper", type=float, default=99.9, show_default=True,
+              help="Upper percentile for brightness stretching")
+@click.option("--skip-existing", is_flag=True, default=False,
+              help="Skip zarrs that already have thumbnails convention metadata")
+@click.option("-v", "--verbose", is_flag=True, default=False,
+              help="Enable verbose logging")
+def embed(input_csv: str, zarr_base_url: Optional[str],
+          thumbnail_base_url: Optional[str], size: int, jpeg_quality: int,
+          p_lower: float, p_upper: float, skip_existing: bool, verbose: bool):
+    """Embed thumbnails into zarr containers using the thumbnails convention.
+
+    Reads a CSV with zarr paths in the first column and existing thumbnail
+    paths in the second column. For each row:
+
+    \b
+      1. Copies the source thumbnail to <zarr>/thumbnails/thumbnail.<ext>
+      2. Generates a downsampled, brightness-adjusted JPEG at
+         <zarr>/thumbnails/thumbnail_<SIZE>.jpg
+      3. Registers both in the zarr root's attrs per the thumbnails
+         convention (https://github.com/clbarnes/zarr-convention-thumbnails)
+    """
+    logger.remove()
+    logger.add(sys.stderr, level="DEBUG" if verbose else "INFO")
+
+    df = pd.read_csv(input_csv, sep=None, engine="python")
+    if df.shape[1] < 2:
+        raise click.UsageError("Input CSV must have at least 2 columns (zarr path, thumbnail path)")
+
+    zarr_col, thumb_col = df.columns[0], df.columns[1]
+    logger.info(f"Read {len(df)} rows; using columns '{zarr_col}' (zarr) and '{thumb_col}' (thumbnail)")
+
+    n_ok = 0
+    n_fail = 0
+    for i, row in df.iterrows():
+        zarr_path = str(row[zarr_col])
+        thumb_path = row[thumb_col]
+        if pd.isna(thumb_path) or not str(thumb_path).strip():
+            logger.warning(f"[{i+1}/{len(df)}] No thumbnail for {zarr_path}, skipping")
+            continue
+        thumb_path = str(thumb_path)
+
+        zarr_uri = _resolve(zarr_path, zarr_base_url)
+        thumb_uri = _resolve(thumb_path, thumbnail_base_url)
+        logger.info(f"[{i+1}/{len(df)}] {zarr_uri}")
+
+        try:
+            _embed_one(
+                zarr_uri, thumb_uri, size, jpeg_quality,
+                p_lower, p_upper, skip_existing,
+            )
+            n_ok += 1
+        except Exception as e:
+            logger.error(f"Failed to embed thumbnail for {zarr_uri}: {e}")
+            n_fail += 1
+
+    logger.info(f"Embedded {n_ok} thumbnail(s), {n_fail} failure(s)")
+
+
+def _embed_one(zarr_uri: str, thumb_uri: str, size: int, jpeg_quality: int,
+               p_lower: float, p_upper: float, skip_existing: bool) -> None:
+    fs = get_filestore(zarr_uri)
+    store = fs.get_store("")
+
+    if skip_existing and has_thumbnails(store):
+        logger.debug("Existing thumbnails metadata found, skipping")
+        return
+
+    src_bytes = _read_image_bytes(thumb_uri)
+    src_ext = os.path.splitext(thumb_uri)[1].lower()
+    if not src_ext:
+        raise ValueError(f"Thumbnail has no file extension: {thumb_uri}")
+
+    orig_path = f"thumbnails/thumbnail{src_ext}"
+    down_path = f"thumbnails/thumbnail_{size}.jpg"
+
+    orig_w, orig_h = _image_dimensions(src_bytes)
+    logger.debug(f"Original thumbnail: {orig_w}x{orig_h} → {orig_path}")
+    store[orig_path] = src_bytes
+
+    down_bytes, down_w, down_h = _downsample_with_brightness(
+        src_bytes, size, jpeg_quality, p_lower, p_upper,
+    )
+    logger.debug(f"Downsampled thumbnail: {down_w}x{down_h} → {down_path}")
+    store[down_path] = down_bytes
+
+    entries = [
+        build_entry(
+            path=down_path,
+            width=down_w,
+            height=down_h,
+            description=f"Downsampled thumbnail ({size}px longest edge)",
+            attributes={
+                "software_url": SOFTWARE_URL,
+                "p_lower": p_lower,
+                "p_upper": p_upper,
+                "jpeg_quality": jpeg_quality,
+            },
+        ),
+        build_entry(
+            path=orig_path,
+            width=orig_w,
+            height=orig_h,
+            media_type=guess_media_type(orig_path),
+            description="Full-resolution source thumbnail",
+            attributes={
+                "original_filename": os.path.basename(thumb_uri),
+            },
+        ),
+    ]
+    register(store, entries)
+    logger.debug("Registered thumbnails in .zattrs")

--- a/cli/zarrcade_cli/core/zarr_thumbnails.py
+++ b/cli/zarrcade_cli/core/zarr_thumbnails.py
@@ -1,0 +1,136 @@
+"""Zarr Thumbnail Convention support.
+
+Implements https://github.com/clbarnes/zarr-convention-thumbnails
+(UUID: 49326c01-1180-4743-b15f-f7157038a6ab)
+
+Reads and writes attrs directly against the store so it works on both
+zarr v2 (`.zattrs`) and zarr v3 (`zarr.json`) without depending on a
+particular zarr-python major version.
+"""
+
+import json
+import os
+from typing import Optional
+
+CONVENTION_NAME = "thumbnails"
+CONVENTION_UUID = "49326c01-1180-4743-b15f-f7157038a6ab"
+CONVENTION_SPEC_URL = "https://github.com/clbarnes/zarr-convention-thumbnails"
+CONVENTION_SCHEMA_URL = (
+    "https://raw.githubusercontent.com/zarr-conventions/thumbnails/"
+    "refs/tags/v1/schema.json"
+)
+SOFTWARE_URL = "https://github.com/JaneliaSciComp/zarrcade"
+
+MEDIA_TYPES = {
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".png": "image/png",
+    ".gif": "image/gif",
+    ".webp": "image/webp",
+    ".avif": "image/avif",
+}
+
+
+def guess_media_type(path: str) -> str:
+    """Return the MIME type for a thumbnail path based on its extension."""
+    ext = os.path.splitext(path)[1].lower()
+    if ext not in MEDIA_TYPES:
+        raise ValueError(f"Unsupported thumbnail extension: {ext}")
+    return MEDIA_TYPES[ext]
+
+
+def build_entry(
+    path: str,
+    width: int,
+    height: int,
+    media_type: Optional[str] = None,
+    description: Optional[str] = None,
+    attributes: Optional[dict] = None,
+) -> dict:
+    """Build a thumbnail entry matching the convention schema."""
+    if ".." in path.split("/") or "." in path.split("/"):
+        raise ValueError(f"Thumbnail path must not contain '.' or '..' segments: {path}")
+    entry = {
+        "width": int(width),
+        "height": int(height),
+        "media_type": media_type or guess_media_type(path),
+        "path": path,
+    }
+    if description:
+        entry["description"] = description
+    if attributes:
+        entry["attributes"] = attributes
+    return entry
+
+
+def _get_bytes(store, key: str) -> Optional[bytes]:
+    try:
+        return store[key]
+    except KeyError:
+        return None
+
+
+def load_root_metadata(store) -> tuple[dict, str, Optional[dict]]:
+    """Load the root node's user attrs.
+
+    Returns (attrs, zarr_format, raw_v3_meta). `zarr_format` is "v2" or "v3".
+    For v3, `raw_v3_meta` is the full parsed `zarr.json`; for v2 it is None.
+    """
+    raw_v3 = _get_bytes(store, "zarr.json")
+    if raw_v3 is not None:
+        meta = json.loads(raw_v3)
+        if meta.get("zarr_format") == 3:
+            return dict(meta.get("attributes", {})), "v3", meta
+
+    raw_zattrs = _get_bytes(store, ".zattrs")
+    if raw_zattrs is not None:
+        return json.loads(raw_zattrs), "v2", None
+
+    # v2 node without user attrs yet
+    if _get_bytes(store, ".zgroup") is not None or _get_bytes(store, ".zarray") is not None:
+        return {}, "v2", None
+
+    raise ValueError(
+        "No zarr root metadata found at store root "
+        "(expected .zattrs, .zgroup, .zarray, or zarr.json)"
+    )
+
+
+def save_root_attrs(store, attrs: dict, zarr_format: str,
+                    raw_v3_meta: Optional[dict]) -> None:
+    """Write the full user attrs dict back to the appropriate metadata file."""
+    if zarr_format == "v3":
+        if raw_v3_meta is None:
+            raise ValueError("v3 format requires raw_v3_meta from load_root_metadata")
+        meta = dict(raw_v3_meta)
+        meta["attributes"] = attrs
+        store["zarr.json"] = json.dumps(meta, indent=2).encode("utf-8")
+    else:
+        store[".zattrs"] = json.dumps(attrs, indent=2).encode("utf-8")
+
+
+def has_thumbnails(store) -> bool:
+    """Return True if the store's root already has a `thumbnails` attr."""
+    attrs, _, _ = load_root_metadata(store)
+    return CONVENTION_NAME in attrs
+
+
+def register(store, entries: list) -> None:
+    """Write the thumbnail entries to the zarr root's attrs and register
+    the convention in `zarr_conventions` (dedup'd by name).
+    """
+    attrs, version, raw_v3 = load_root_metadata(store)
+
+    registration = {
+        "name": CONVENTION_NAME,
+        "uuid": CONVENTION_UUID,
+        "spec_url": CONVENTION_SPEC_URL,
+        "schema_url": CONVENTION_SCHEMA_URL,
+    }
+    conventions = [c for c in attrs.get("zarr_conventions", [])
+                   if c.get("name") != CONVENTION_NAME]
+    conventions.append(registration)
+    attrs["zarr_conventions"] = conventions
+    attrs[CONVENTION_NAME] = list(entries)
+
+    save_root_attrs(store, attrs, version, raw_v3)

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -183,6 +183,15 @@ function App() {
               </a>
             </div>
 
+            <Pagination
+              currentPage={currentPage}
+              totalPages={totalPages}
+              totalItems={totalItems}
+              startIndex={startIndex}
+              endIndex={endIndex}
+              onPageChange={goToPage}
+            />
+
             <Gallery
               data={paginatedData}
               allData={data}

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -18,18 +18,26 @@ import { Gallery } from './components/Gallery';
 import { Pagination } from './components/Pagination';
 import { ImageDetail } from './components/ImageDetail';
 import { Footer } from './components/Footer';
+import { Welcome } from './components/Welcome';
 
 function App() {
   const [config, setConfig] = useState<AppConfig | null>(null);
   const [configError, setConfigError] = useState<string | null>(null);
+  const [configLoaded, setConfigLoaded] = useState(false);
   const [selectedImageIndex, setSelectedImageIndex] = useState<number | null>(null);
   const { theme, toggleTheme } = useTheme();
 
   // Load configuration
   useEffect(() => {
     loadConfig()
-      .then(setConfig)
-      .catch((e) => setConfigError(e.message));
+      .then((c) => {
+        setConfig(c);
+        setConfigLoaded(true);
+      })
+      .catch((e) => {
+        setConfigError(e.message);
+        setConfigLoaded(true);
+      });
   }, []);
 
   // Load data
@@ -105,22 +113,40 @@ function App() {
 
   const selectedImage = selectedImageIndex !== null ? data[selectedImageIndex] ?? null : null;
 
-  // Error state
+  // Config load failed (malformed JSON, network error, etc.)
   if (configError) {
     return (
       <div className="error-container">
         <h2>Configuration Error</h2>
         <p>{configError}</p>
-        <p>
-          Please provide a <code>config.json</code> file or use the{' '}
-          <code>?data=URL</code> parameter.
-        </p>
       </div>
     );
   }
 
-  // Loading state
-  if (!config || loading) {
+  // Still loading config
+  if (!configLoaded) {
+    return (
+      <div className="loading-container">
+        <p>Loading...</p>
+      </div>
+    );
+  }
+
+  // Config loaded but no dataUrl set — show setup instructions
+  if (!config) {
+    return (
+      <div className="app">
+        <TopBar config={null} theme={theme} onToggleTheme={toggleTheme} />
+        <main className="main-content">
+          <Welcome />
+        </main>
+        <Footer config={null} />
+      </div>
+    );
+  }
+
+  // Data still loading
+  if (loading) {
     return (
       <div className="loading-container">
         <p>Loading...</p>

--- a/web/src/components/Gallery.tsx
+++ b/web/src/components/Gallery.tsx
@@ -21,13 +21,15 @@ export function Gallery({ data, allData, config, onImageClick }: GalleryProps) {
     );
   }
 
+  const pathColumn = config.data?.pathColumn || 'path';
   return (
     <div className="gallery">
-      {data.map((row, i) => {
+      {data.map((row) => {
         const globalIndex = allData.indexOf(row);
+        const rowKey = row[pathColumn] !== undefined ? String(row[pathColumn]) : `row-${globalIndex}`;
         return (
           <ImageCard
-            key={i}
+            key={rowKey}
             row={row}
             config={config}
             onClick={() => onImageClick(globalIndex)}

--- a/web/src/components/ImageCard.tsx
+++ b/web/src/components/ImageCard.tsx
@@ -2,7 +2,7 @@
  * Image card component for gallery
  */
 
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import type { ImageRow, AppConfig, Viewer } from '../types';
 import {
   getCsvThumbnailUrl,
@@ -41,8 +41,26 @@ export function ImageCard({ row, config, onClick }: ImageCardProps) {
     inView
   );
 
-  const thumbnailUrl =
-    csvThumbnail ?? conventionThumbnail?.url ?? THUMBNAIL_PLACEHOLDER;
+  const resolvedUrl = csvThumbnail ?? conventionThumbnail?.url ?? null;
+
+  // Preload the resolved thumbnail. Only display it once it has decoded;
+  // until then, show the placeholder. This prevents stale images from the
+  // previous page sticking around on slow connections.
+  const [displayUrl, setDisplayUrl] = useState<string>(THUMBNAIL_PLACEHOLDER);
+  useEffect(() => {
+    setDisplayUrl(THUMBNAIL_PLACEHOLDER);
+    if (!resolvedUrl) return;
+    const img = new Image();
+    let cancelled = false;
+    img.onload = () => { if (!cancelled) setDisplayUrl(resolvedUrl); };
+    img.onerror = () => { if (!cancelled) setDisplayUrl(THUMBNAIL_PLACEHOLDER); };
+    img.src = resolvedUrl;
+    return () => {
+      cancelled = true;
+      img.onload = null;
+      img.onerror = null;
+    };
+  }, [resolvedUrl]);
 
   const handleCopyLink = async () => {
     const success = await copyToClipboard(imagePath);
@@ -61,7 +79,7 @@ export function ImageCard({ row, config, onClick }: ImageCardProps) {
     >
       <div className="image-card-thumbnail">
         <img
-          src={thumbnailUrl}
+          src={displayUrl}
           alt={title}
           loading="lazy"
           onError={(e) => {

--- a/web/src/components/ImageCard.tsx
+++ b/web/src/components/ImageCard.tsx
@@ -4,9 +4,16 @@
 
 import { useState } from 'react';
 import type { ImageRow, AppConfig, Viewer } from '../types';
-import { getImagePath, getThumbnailUrl, getTitle } from '../utils/csv';
+import {
+  getCsvThumbnailUrl,
+  getImagePath,
+  getTitle,
+  THUMBNAIL_PLACEHOLDER,
+} from '../utils/csv';
 import { getViewerUrl, getEnabledViewers } from '../utils/viewers';
 import { copyToClipboard } from '../utils/clipboard';
+import { useIntersectionObserver } from '../hooks/useIntersectionObserver';
+import { useZarrThumbnail } from '../hooks/useZarrThumbnail';
 
 interface ImageCardProps {
   row: ImageRow;
@@ -14,13 +21,28 @@ interface ImageCardProps {
   onClick: () => void;
 }
 
+const THUMBNAIL_TARGET_SIZE = 300;
+
 export function ImageCard({ row, config, onClick }: ImageCardProps) {
   const [showCopied, setShowCopied] = useState(false);
 
   const imagePath = getImagePath(row, config);
-  const thumbnailUrl = getThumbnailUrl(row, config);
+  const csvThumbnail = getCsvThumbnailUrl(row, config);
   const title = getTitle(row, config);
   const viewers = getEnabledViewers(config.viewers);
+
+  const { ref, inView } = useIntersectionObserver<HTMLDivElement>({
+    rootMargin: '200px',
+  });
+
+  const conventionThumbnail = useZarrThumbnail(
+    csvThumbnail ? null : imagePath,
+    THUMBNAIL_TARGET_SIZE,
+    inView
+  );
+
+  const thumbnailUrl =
+    csvThumbnail ?? conventionThumbnail?.url ?? THUMBNAIL_PLACEHOLDER;
 
   const handleCopyLink = async () => {
     const success = await copyToClipboard(imagePath);
@@ -31,14 +53,19 @@ export function ImageCard({ row, config, onClick }: ImageCardProps) {
   };
 
   return (
-    <div className="image-card" onClick={onClick} style={{ cursor: 'pointer' }}>
+    <div
+      ref={ref}
+      className="image-card"
+      onClick={onClick}
+      style={{ cursor: 'pointer' }}
+    >
       <div className="image-card-thumbnail">
         <img
           src={thumbnailUrl}
           alt={title}
           loading="lazy"
           onError={(e) => {
-            (e.target as HTMLImageElement).src = './icons/zarr.jpg';
+            (e.target as HTMLImageElement).src = THUMBNAIL_PLACEHOLDER;
           }}
         />
         <div className="image-card-overlay">

--- a/web/src/components/ImageDetail.tsx
+++ b/web/src/components/ImageDetail.tsx
@@ -4,9 +4,18 @@
 
 import { useState } from 'react';
 import type { ImageRow, AppConfig } from '../types';
-import { getImagePath, getThumbnailUrl, getTitle, getVisibleColumns } from '../utils/csv';
+import {
+  getCsvThumbnailUrl,
+  getImagePath,
+  getTitle,
+  getVisibleColumns,
+  THUMBNAIL_PLACEHOLDER,
+} from '../utils/csv';
 import { getViewerUrl, getEnabledViewers } from '../utils/viewers';
 import { copyToClipboard } from '../utils/clipboard';
+import { useZarrThumbnail } from '../hooks/useZarrThumbnail';
+
+const THUMBNAIL_TARGET_SIZE = 400;
 
 interface ImageDetailProps {
   row: ImageRow;
@@ -19,7 +28,14 @@ export function ImageDetail({ row, columns, config, onBack }: ImageDetailProps) 
   const [showCopied, setShowCopied] = useState(false);
 
   const imagePath = getImagePath(row, config);
-  const thumbnailUrl = getThumbnailUrl(row, config);
+  const csvThumbnail = getCsvThumbnailUrl(row, config);
+  const conventionThumbnail = useZarrThumbnail(
+    csvThumbnail ? null : imagePath,
+    THUMBNAIL_TARGET_SIZE,
+    true
+  );
+  const thumbnailUrl =
+    csvThumbnail ?? conventionThumbnail?.url ?? THUMBNAIL_PLACEHOLDER;
   const title = getTitle(row, config);
   const viewers = getEnabledViewers(config.viewers);
   const visibleColumns = getVisibleColumns(columns, config);
@@ -74,7 +90,7 @@ export function ImageDetail({ row, columns, config, onBack }: ImageDetailProps) 
             src={thumbnailUrl}
             alt={title}
             onError={(e) => {
-              (e.target as HTMLImageElement).src = './icons/zarr.jpg';
+              (e.target as HTMLImageElement).src = THUMBNAIL_PLACEHOLDER;
             }}
           />
         </div>

--- a/web/src/components/Welcome.tsx
+++ b/web/src/components/Welcome.tsx
@@ -1,0 +1,60 @@
+/**
+ * Shown when the SPA loads without any data/config configured.
+ * Explains how to point it at a dataset.
+ */
+
+export function Welcome() {
+  const base = `${window.location.origin}${window.location.pathname}`;
+
+  return (
+    <div className="welcome">
+      <h1>Zarrcade</h1>
+      <p className="welcome-tagline">
+        Browse, search, and visualize collections of OME-NGFF (OME-Zarr) images.
+      </p>
+
+      <section>
+        <h2>Getting started</h2>
+        <p>
+          Zarrcade reads a CSV (or TSV) file describing your images. Point it at
+          your data with one of these methods:
+        </p>
+
+        <h3>1. Pass a data URL</h3>
+        <p>
+          The simplest way — append <code>?data=</code> to the URL with a link to your CSV:
+        </p>
+        <pre><code>{base}?data=https://example.com/images.csv</code></pre>
+
+        <h3>2. Pass a config URL</h3>
+        <p>
+          For more control (custom columns, filters, viewers, branding), supply
+          a JSON configuration file:
+        </p>
+        <pre><code>{base}?config=https://example.com/config.json</code></pre>
+
+        <h3>3. Bundle a config.json</h3>
+        <p>
+          If you're self-hosting, drop a <code>config.json</code> next to the
+          SPA's <code>index.html</code>. It will be loaded automatically.
+        </p>
+      </section>
+
+      <section>
+        <h2>Need more?</h2>
+        <p>
+          See the{' '}
+          <a
+            href="https://github.com/JaneliaSciComp/zarrcade"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            project documentation
+          </a>{' '}
+          for the full configuration reference and CLI tools for generating
+          data and thumbnails.
+        </p>
+      </section>
+    </div>
+  );
+}

--- a/web/src/config.ts
+++ b/web/src/config.ts
@@ -53,7 +53,7 @@ const DEFAULT_CONFIG: Partial<AppConfig> = {
  * Load configuration from various sources
  * Priority: URL param > /config.json > defaults
  */
-export async function loadConfig(): Promise<AppConfig> {
+export async function loadConfig(): Promise<AppConfig | null> {
   // Check for config URL in query params
   const urlParams = new URLSearchParams(window.location.search);
   const configUrl = urlParams.get('config');
@@ -118,7 +118,7 @@ export async function loadConfig(): Promise<AppConfig> {
   } as AppConfig;
 
   if (!mergedConfig.dataUrl) {
-    throw new Error('No data URL configured. Set dataUrl in config.json or use ?data= parameter.');
+    return null;
   }
 
   return mergedConfig;

--- a/web/src/hooks/useIntersectionObserver.ts
+++ b/web/src/hooks/useIntersectionObserver.ts
@@ -1,0 +1,31 @@
+/**
+ * Observe when an element scrolls into the viewport. Disconnects once
+ * seen — used for one-shot lazy work (e.g. fetching thumbnails).
+ */
+
+import { useEffect, useRef, useState } from 'react';
+
+export function useIntersectionObserver<T extends Element>(
+  options?: IntersectionObserverInit
+) {
+  const ref = useRef<T | null>(null);
+  const [inView, setInView] = useState(false);
+
+  useEffect(() => {
+    if (inView) return;
+    const el = ref.current;
+    if (!el) return;
+
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setInView(true);
+        observer.disconnect();
+      }
+    }, options);
+
+    observer.observe(el);
+    return () => observer.disconnect();
+  }, [inView, options]);
+
+  return { ref, inView };
+}

--- a/web/src/hooks/useZarrThumbnail.ts
+++ b/web/src/hooks/useZarrThumbnail.ts
@@ -1,0 +1,28 @@
+/**
+ * Lazy-fetch a thumbnail registered on a zarr via the thumbnails convention.
+ * Only runs when `enabled` is true (used with viewport observation on cards).
+ */
+
+import { useEffect, useState } from 'react';
+import { fetchBestThumbnail, type SelectedThumbnail } from '../utils/zarrThumbnails';
+
+export function useZarrThumbnail(
+  zarrUrl: string | null,
+  targetSize: number,
+  enabled: boolean
+): SelectedThumbnail | null {
+  const [thumb, setThumb] = useState<SelectedThumbnail | null>(null);
+
+  useEffect(() => {
+    if (!enabled || !zarrUrl) return;
+    let cancelled = false;
+    fetchBestThumbnail(zarrUrl, targetSize).then((result) => {
+      if (!cancelled) setThumb(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [enabled, zarrUrl, targetSize]);
+
+  return thumb;
+}

--- a/web/src/hooks/useZarrThumbnail.ts
+++ b/web/src/hooks/useZarrThumbnail.ts
@@ -14,6 +14,7 @@ export function useZarrThumbnail(
   const [thumb, setThumb] = useState<SelectedThumbnail | null>(null);
 
   useEffect(() => {
+    setThumb(null);
     if (!enabled || !zarrUrl) return;
     let cancelled = false;
     fetchBestThumbnail(zarrUrl, targetSize).then((result) => {

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -204,13 +204,18 @@ body {
 .image-card-thumbnail {
   position: relative;
   width: 100%;
+  height: 300px;
   display: flex;
+  align-items: center;
   justify-content: center;
+  border-radius: var(--pico-border-radius);
+  overflow: hidden;
 }
 
 .image-card-thumbnail img {
   max-width: 100%;
-  max-height: 300px;
+  max-height: 100%;
+  width: auto;
   height: auto;
   border-radius: var(--pico-border-radius);
   transition: opacity 0.2s;
@@ -443,6 +448,8 @@ body {
 .image-detail-thumbnail img {
   max-width: 400px;
   max-height: 400px;
+  width: auto;
+  height: auto;
   border-radius: var(--pico-border-radius);
 }
 

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -3,22 +3,58 @@
 /* Import Pico CSS from CDN */
 @import url('https://cdn.jsdelivr.net/npm/@picocss/pico@2/css/pico.min.css');
 
-/* CSS Variables */
+/* Base typography + sizing vars (theme-neutral) */
 :root {
-  --pico-primary: #524c84;
-  --pico-primary-hover: #7b78b8;
-  --separator-color: #999;
   --pico-font-family-sans-serif: Inter, system-ui, "Segoe UI", Roboto, Oxygen, Ubuntu, Cantarell, Helvetica, Arial, "Helvetica Neue", sans-serif;
   --pico-font-size: 87.5%;
   --pico-line-height: 1.25;
   --pico-form-element-spacing-vertical: 0.5rem;
   --pico-form-element-spacing-horizontal: 1.0rem;
   --pico-border-radius: 0.375rem;
+  --separator-color: #999;
+}
+
+/* Palette
+   Accent / primary: teal-600 (#0d9488) — teal-700 (#0f766e) on hover
+   Secondary:        slate-600 (#475569) — slate-700 (#334155) on hover
+   Chrome bars:      slate-800 (#1e293b)
+   Gallery (dark):   pure black
+*/
+:root:not([data-theme="dark"]),
+[data-theme="light"],
+[data-theme="dark"] {
+  --pico-primary: #0d9488;
+  --pico-primary-background: #0d9488;
+  --pico-primary-border: #0d9488;
+  --pico-primary-underline: #0d9488;
+  --pico-primary-hover: #0f766e;
+  --pico-primary-hover-background: #0f766e;
+  --pico-primary-hover-border: #0f766e;
+  --pico-primary-hover-underline: #0f766e;
+  --pico-primary-focus: rgba(13, 148, 136, 0.25);
+  --pico-primary-inverse: #fff;
+
+  --pico-secondary: #475569;
+  --pico-secondary-background: #475569;
+  --pico-secondary-border: #475569;
+  --pico-secondary-underline: #475569;
+  --pico-secondary-hover: #334155;
+  --pico-secondary-hover-background: #334155;
+  --pico-secondary-hover-border: #334155;
+  --pico-secondary-hover-underline: #334155;
+  --pico-secondary-focus: rgba(71, 85, 105, 0.25);
+  --pico-secondary-inverse: #fff;
 }
 
 [data-theme="dark"] {
-  --separator-color: #666666;
-  --pico-background-color: #111;
+  --separator-color: #334155;
+  --pico-background-color: #000;
+}
+
+/* Links inherit the Pico primary var, with a subtle underline. */
+a {
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 /* Base Layout */
@@ -69,7 +105,7 @@ body {
 
 /* Top Bar */
 .top-bar {
-  background-color: black;
+  background-color: #1e293b;
   color: white;
   padding: 0.5rem 1rem;
   display: flex;
@@ -165,18 +201,19 @@ body {
 .gallery-action-link {
   background: none;
   border: none;
-  color: var(--pico-primary);
   cursor: pointer;
   font-size: 0.9rem;
   padding: 0;
-  text-decoration: none;
   display: inline-flex;
   align-items: center;
   gap: 0.4rem;
+  color: var(--pico-primary);
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .gallery-action-link:hover {
-  text-decoration: underline;
+  color: var(--pico-primary-hover);
 }
 
 /* Gallery Grid */
@@ -208,7 +245,6 @@ body {
   display: flex;
   align-items: center;
   justify-content: center;
-  border-radius: var(--pico-border-radius);
   overflow: hidden;
 }
 
@@ -356,7 +392,7 @@ body {
 
 /* Footer */
 .footer {
-  background-color: black;
+  background-color: #1e293b;
   color: white;
   padding: 1rem 2rem;
   margin-top: auto;
@@ -398,10 +434,12 @@ body {
   cursor: pointer;
   font-size: 1rem;
   padding: 0.25rem 0;
+  text-decoration: underline;
+  text-underline-offset: 2px;
 }
 
 .image-detail-back:hover {
-  text-decoration: underline;
+  color: var(--pico-primary-hover);
 }
 
 .image-detail-header {

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -81,6 +81,55 @@ body {
   width: 100%;
 }
 
+/* Welcome / getting started screen */
+.welcome {
+  max-width: 760px;
+  margin: 2rem auto;
+  padding: 0 1rem;
+  line-height: 1.6;
+}
+
+.welcome h1 {
+  margin-bottom: 0.25rem;
+}
+
+.welcome-tagline {
+  font-size: 1.1rem;
+  color: var(--pico-muted-color);
+  margin-bottom: 2rem;
+}
+
+.welcome section {
+  margin-bottom: 2rem;
+}
+
+.welcome h2 {
+  margin-top: 0;
+  margin-bottom: 0.75rem;
+  font-size: 1.25rem;
+}
+
+.welcome h3 {
+  margin-top: 1.5rem;
+  margin-bottom: 0.5rem;
+  font-size: 1rem;
+  font-weight: 600;
+}
+
+.welcome pre {
+  background: var(--pico-code-background-color);
+  color: var(--pico-code-color);
+  padding: 0.75rem 1rem;
+  border-radius: var(--pico-border-radius);
+  overflow-x: auto;
+  font-size: 0.85rem;
+  margin: 0.5rem 0 1rem;
+}
+
+.welcome code {
+  font-size: 0.9em;
+}
+
 /* Loading and Error States */
 .loading-container,
 .error-container {

--- a/web/src/styles/index.css
+++ b/web/src/styles/index.css
@@ -369,9 +369,9 @@ body {
 
 .pagination-arrow:hover:not(:disabled),
 .pagination-page:hover:not(.active) {
-  background-color: var(--pico-primary-hover);
+  background-color: var(--pico-primary);
   color: white;
-  border-color: var(--pico-primary-hover);
+  border-color: var(--pico-primary);
 }
 
 .pagination-arrow:disabled {
@@ -380,9 +380,12 @@ body {
 }
 
 .pagination-page.active {
-  background-color: var(--pico-primary);
+  background-color: #134e4a;
   color: white;
-  border-color: var(--pico-primary);
+  border-color: #134e4a;
+  font-weight: 700;
+  box-shadow: 0 0 0 2px rgba(19, 78, 74, 0.25);
+  cursor: default;
 }
 
 .pagination-ellipsis {

--- a/web/src/utils/csv.ts
+++ b/web/src/utils/csv.ts
@@ -45,36 +45,42 @@ export function getImagePath(row: ImageRow, config: AppConfig): string {
   return pathStr;
 }
 
-/**
- * Get the thumbnail URL for an image row
- */
-export function getThumbnailUrl(row: ImageRow, config: AppConfig): string {
-  const thumbnailColumn = config.data?.thumbnailColumn;
+export const THUMBNAIL_PLACEHOLDER = './icons/zarr.jpg';
 
-  // If thumbnail column is configured and has a value, use it
-  if (thumbnailColumn) {
-    const thumbnail = row[thumbnailColumn];
-    if (thumbnail) {
-      const thumbStr = String(thumbnail);
-      // If already a full URL, return as-is
-      if (thumbStr.startsWith('http://') || thumbStr.startsWith('https://')) {
-        return thumbStr;
-      }
-      // Prepend thumbnail base URL if configured
-      const thumbBase = config.data?.thumbnailBaseUrl;
-      if (thumbBase) {
-        return `${thumbBase.replace(/\/$/, '')}/${thumbStr.replace(/^\//, '')}`;
-      }
-      // Resolve relative to the CSV data URL
-      if (config.dataUrl) {
-        return resolveRelativeUrl(thumbStr, config.dataUrl);
-      }
-      return thumbStr;
-    }
+/**
+ * Resolve a CSV-provided thumbnail URL, or return null if the row has none.
+ */
+export function getCsvThumbnailUrl(row: ImageRow, config: AppConfig): string | null {
+  const thumbnailColumn = config.data?.thumbnailColumn;
+  if (!thumbnailColumn) return null;
+
+  const thumbnail = row[thumbnailColumn];
+  if (!thumbnail) return null;
+
+  const thumbStr = String(thumbnail);
+  if (thumbStr.startsWith('http://') || thumbStr.startsWith('https://')) {
+    return thumbStr;
   }
 
-  // Fallback to default placeholder
-  return './icons/zarr.jpg';
+  const thumbBase = config.data?.thumbnailBaseUrl;
+  if (thumbBase) {
+    return `${thumbBase.replace(/\/$/, '')}/${thumbStr.replace(/^\//, '')}`;
+  }
+
+  if (config.dataUrl) {
+    return resolveRelativeUrl(thumbStr, config.dataUrl);
+  }
+
+  return thumbStr;
+}
+
+/**
+ * Get the thumbnail URL for an image row, falling back to a placeholder.
+ * Callers that want to try the zarr convention should use `getCsvThumbnailUrl`
+ * and handle `null` themselves.
+ */
+export function getThumbnailUrl(row: ImageRow, config: AppConfig): string {
+  return getCsvThumbnailUrl(row, config) ?? THUMBNAIL_PLACEHOLDER;
 }
 
 /**

--- a/web/src/utils/zarrThumbnails.ts
+++ b/web/src/utils/zarrThumbnails.ts
@@ -1,0 +1,98 @@
+/**
+ * Read thumbnails registered on a zarr via the thumbnails convention:
+ * https://github.com/clbarnes/zarr-convention-thumbnails
+ *
+ * Only `zarr.json` (v3) is consulted.
+ */
+
+interface ThumbnailEntry {
+  width: number;
+  height: number;
+  media_type: string;
+  description?: string;
+  path?: string;
+  url?: string;
+}
+
+export interface SelectedThumbnail {
+  url: string;
+  width: number;
+  height: number;
+}
+
+const cache = new Map<string, Promise<SelectedThumbnail | null>>();
+
+function longestEdge(t: { width: number; height: number }): number {
+  return Math.max(t.width, t.height);
+}
+
+/**
+ * Pick the entry closest to the target. Prefer one slightly larger
+ * (so it never needs to be upsampled when displayed); if none are
+ * at least target size, pick the largest available.
+ */
+function selectBest(entries: ThumbnailEntry[], target: number): ThumbnailEntry | null {
+  if (!entries.length) return null;
+  const withEdge = entries.map((e) => ({ e, edge: longestEdge(e) }));
+
+  const geq = withEdge.filter((x) => x.edge >= target).sort((a, b) => a.edge - b.edge);
+  if (geq.length > 0) return geq[0].e;
+
+  const sorted = [...withEdge].sort((a, b) => b.edge - a.edge);
+  return sorted[0].e;
+}
+
+function resolveEntryUrl(entry: ThumbnailEntry, zarrUrl: string): string | null {
+  if (entry.url) return entry.url;
+  if (entry.path) return zarrUrl.replace(/\/$/, '') + '/' + entry.path.replace(/^\//, '');
+  return null;
+}
+
+export function fetchBestThumbnail(
+  zarrUrl: string,
+  targetSize: number
+): Promise<SelectedThumbnail | null> {
+  const key = `${zarrUrl}::${targetSize}`;
+  const hit = cache.get(key);
+  if (hit) return hit;
+
+  const metadataUrl = zarrUrl.replace(/\/$/, '') + '/zarr.json';
+
+  const promise: Promise<SelectedThumbnail | null> = (async () => {
+    let res: Response;
+    try {
+      res = await fetch(metadataUrl);
+    } catch (err) {
+      console.error(`[zarr-thumbnails] network error fetching ${metadataUrl}:`, err);
+      return null;
+    }
+
+    if (res.status === 404) return null;
+    if (!res.ok) {
+      console.error(`[zarr-thumbnails] ${metadataUrl} responded ${res.status} ${res.statusText}`);
+      return null;
+    }
+
+    let meta: unknown;
+    try {
+      meta = await res.json();
+    } catch (err) {
+      console.error(`[zarr-thumbnails] invalid JSON at ${metadataUrl}:`, err);
+      return null;
+    }
+
+    const attrs = (meta as { attributes?: { thumbnails?: unknown } })?.attributes;
+    const entries = attrs?.thumbnails;
+    if (!Array.isArray(entries) || entries.length === 0) return null;
+
+    const best = selectBest(entries as ThumbnailEntry[], targetSize);
+    if (!best) return null;
+
+    const url = resolveEntryUrl(best, zarrUrl);
+    if (!url) return null;
+    return { url, width: best.width, height: best.height };
+  })();
+
+  cache.set(key, promise);
+  return promise;
+}


### PR DESCRIPTION
# Thumbnails via the zarr thumbnails convention

## Summary

Adds end-to-end support for the [zarr-convention-thumbnails](https://github.com/clbarnes/zarr-convention-thumbnails) spec (UUID `49326c01-1180-4743-b15f-f7157038a6ab`), plus a batch of UI polish on top.

- A new CLI command, `zarrcade embed`, takes a CSV of `(zarr path, thumbnail path)` pairs and writes the thumbnails *into* each zarr container under the `thumbnails/` prefix, registering them in the zarr root attrs per the convention.
- The SPA now reads that same convention at render time. When the CSV has no `thumbnailColumn` value for a row, the gallery fetches `zarr.json`, picks the best registered entry for the display size, and shows it — falling back silently to the placeholder if the zarr has no thumbnails.
- All the attr reads/writes are version-agnostic (v2 `.zattrs` and v3 `zarr.json` both supported), without depending on a particular zarr-python major.

## Why

Thumbnails in v2.x Zarrcade had to be generated and hosted separately, and each deployment had to cobble together URL schemes to tie them back to their zarrs. The thumbnails convention puts that metadata where it belongs — on the zarr itself — so any consumer (Zarrcade, a viewer, a data browser) can discover them without out-of-band configuration. This PR makes Zarrcade both produce and consume that metadata, and drops the hard dependency on a `thumbnailColumn` in the CSV.

## CLI: `zarrcade embed`

New command in `cli/zarrcade_cli/commands/embed_thumbnails.py`:

- Reads a 2-column CSV (zarr path in col 1, existing thumbnail path in col 2). Both support relative paths with `--zarr-base-url` / `--thumbnail-base-url`, or absolute (`s3://`, `https://`, local).
- For each row: copies the source bytes verbatim to `<zarr>/thumbnails/thumbnail.<ext>`, and generates a brightness-adjusted downsample at `<zarr>/thumbnails/thumbnail_<size>.jpg` (default 300px longest edge, percentile stretching via `--p-lower` / `--p-upper`, JPEG quality via `--jpeg-quality`).
- Registers both in the zarr root attrs under the `thumbnails` key per the spec — `width`, `height`, `media_type`, `path`, `description`, and a small `attributes` payload (`software_url`, `p_lower`/`p_upper`/`jpeg_quality` on the downsample; `original_filename` on the full-res).
- Adds a `zarr_conventions` entry (`name`, `uuid`, `spec_url`, `schema_url`) — idempotent: re-runs replace the existing `thumbnails` registration instead of appending a duplicate.
- `--skip-existing` skips zarrs that already have a `thumbnails` attr.

Supporting module `cli/zarrcade_cli/core/zarr_thumbnails.py`:

- `build_entry()` constructs a spec-compliant entry and rejects `.`/`..` path segments.
- `register()` reads/writes the root attrs directly against the store. Detects v3 (`zarr.json` with top-level `attributes`) vs v2 (`.zattrs` / `.zgroup` / `.zarray`) and writes back to the right file. No dependency on `zarr.open()` so it's insulated from zarr-python version churn.
- `has_thumbnails()` helper for the `--skip-existing` check.

## SPA: convention-aware thumbnail loading

`web/src/utils/zarrThumbnails.ts` fetches `<zarrUrl>/zarr.json`, parses `attributes.thumbnails`, and selects the entry closest to a target size (300 in gallery, 400 in detail), preferring one slightly larger so the browser never has to upsample. Results are memoized per `(zarrUrl, targetSize)` so each zarr is fetched once per session. 404 → silent `null`; other errors → `console.error`.

`web/src/hooks/useZarrThumbnail.ts` wraps that in a hook, gated by an `enabled` flag. `useIntersectionObserver` (new, `rootMargin: 200px`) flips that flag when a gallery card scrolls into view, so convention fetches are viewport-lazy.

`ImageCard.tsx` now composes three sources in order: CSV-provided thumbnail → convention-resolved URL → placeholder. The resolved URL is pre-warmed via a detached `Image()` and only swapped in once it has decoded — this fixes a long-standing desync where, on slow connections, pagination would update the titles instantly while the old thumbnails lingered until the new ones loaded. `ImageDetail.tsx` uses the same fallback but with `enabled = true` since the detail page is always visible.

`utils/csv.ts` splits the previous `getThumbnailUrl` into `getCsvThumbnailUrl` (returns `null` when there's no column/value, so callers can decide to fall back to the convention) and a thin compatibility wrapper.

## Also in this PR (UI polish)

- **Welcome screen** (`components/Welcome.tsx`) replaces the old "Configuration Error" card when the SPA loads with no `dataUrl`. It walks through the three setup paths (`?data=`, `?config=`, bundled `config.json`) with examples prefilled from the current origin.
- **Pagination top + bottom** so you don't have to scroll to the end of a page to jump.
- **Active page highlight**: darker teal (`#134e4a`) with a subtle ring, bold text, and `cursor: default` so the current page is visually distinct from hover.
- **Color scheme refresh**: teal primary (`#0d9488` → `#0f766e`), slate secondary (`#475569` → `#334155`), slate-800 chrome bars, pure black gallery in dark mode. Overrides live inside Pico's theme-scope selectors so the variables actually win specificity.
- **No-upsample display**: gallery thumbnails use `max-width/height: 100%; width/height: auto` so smaller images pad naturally instead of being scaled up.

## Test plan

- [x] `cd cli && pixi run zarrcade embed --input-csv thumbs.csv -v` against a small set of local zarrs — verify `thumbnails/thumbnail.<ext>` and `thumbnails/thumbnail_300.jpg` land inside each zarr and the root metadata file grows a `thumbnails` list + a `zarr_conventions` entry.
- [x] Repeat against a zarr v3 store (`zarr.json`) and confirm the `attributes.thumbnails` field is written correctly without touching other metadata.
- [x] Re-run `embed` with `--skip-existing` and confirm zarrs already registered are skipped.
- [x] Re-run without `--skip-existing` and confirm the `zarr_conventions` entry is replaced rather than duplicated.
- [x] `cd web && npm run dev`, point `config.json` at a CSV with *no* `thumbnailColumn` values — verify cards in view fetch and show thumbnails, off-screen cards stay as placeholder, and devtools shows one `zarr.json` request per zarr (no duplicates).
- [x] Throttle to Slow 3G, paginate — confirm titles and thumbnails swap together, with the placeholder shown while the new image is loading (no stale pixels from the previous page).
- [x] Visit the SPA with no `?data=` / `config.json` — confirm the Welcome screen renders inside the normal top bar / footer, with the three instruction blocks and a working GitHub link.
- [x] Toggle dark mode: gallery background is pure black, header/footer read cleanly against it, active page number is clearly distinguishable from hover.
- [x] `npm run build` type-checks and produces a clean bundle.